### PR TITLE
Fixed issues with input parsing with rabbit nodes

### DIFF
--- a/src/flux_fiction/_core/engine.py
+++ b/src/flux_fiction/_core/engine.py
@@ -995,7 +995,6 @@ class Simulation(object):
                     .format(self.current_time, e)
                 )
                 raise RuntimeError("Quiescent broke") from e
-            logger.debug("meow")
             return
 
     # def is_quiescent(self):

--- a/src/flux_fiction/_core/models.py
+++ b/src/flux_fiction/_core/models.py
@@ -449,38 +449,33 @@ def _parse_float_field(row, field_name, default=0.0) -> float:
 
 _RABBIT_STORAGE_FIELDS = [
     "RabbitStorageGiB",
-    "RabbitStorageGB",
-    "RabbitGB",
+    "RabbitGiB",
     "RABBIT_STORAGE_GIB",
-    "RABBIT_STORAGE_GB",
-    "RABBIT_GB",
-    "SSD_GB",
+    "RABBIT_GIB",
     "SSD_GIB",
 ]
 
+_LEGACY_RABBIT_STORAGE_FIELDS = [
+    "RabbitStorageGB",
+    "RabbitGB",
+    "RABBIT_STORAGE_GB",
+    "RABBIT_GB",
+    "SSD_GB",
+]
 
-def _storage_value_to_gib(raw, default_unit="GiB") -> float:
+def _storage_value_to_gib(raw) -> float:
     if raw in (None, "", "0"):
         return 0.0
     text = str(raw).strip()
-    match = re.match(r"^([0-9]+(?:\.[0-9]+)?)\s*([KMGT]i?B|[KMGT]B)?$", text, re.IGNORECASE)
+    match = re.match(r"^([0-9]+(?:\.[0-9]+)?)\s*(GiB)?$", text, re.IGNORECASE)
     if not match:
-        logger.warning("Invalid Rabbit storage value '%s'; treating as 0", raw)
+        logger.warning(
+            "Invalid Rabbit storage value '%s'; treating as 0. Rabbit storage must be expressed in GiB.",
+            raw,
+        )
         return 0.0
 
-    value = float(match.group(1))
-    unit = (match.group(2) or default_unit).upper()
-    factors = {
-        "KB": 1_000 / (1024 ** 3),
-        "KIB": 1 / (1024 ** 2),
-        "MB": 1_000_000 / (1024 ** 3),
-        "MIB": 1 / 1024,
-        "GB": 1_000_000_000 / (1024 ** 3),
-        "GIB": 1,
-        "TB": 1_000_000_000_000 / (1024 ** 3),
-        "TIB": 1024,
-    }
-    return value * factors.get(unit, 1)
+    return float(match.group(1))
 
 
 def _parse_rabbit_storage_gib(row) -> float:
@@ -490,8 +485,16 @@ def _parse_rabbit_storage_gib(row) -> float:
         if key is None:
             continue
         raw = row.get(key, "")
-        default_unit = "GiB" if "gib" in field.lower() else "GB"
-        return _storage_value_to_gib(raw, default_unit=default_unit)
+        return _storage_value_to_gib(raw)
+    for field in _LEGACY_RABBIT_STORAGE_FIELDS:
+        key = lower_to_key.get(field.lower())
+        if key is None:
+            continue
+        logger.warning(
+            "Rabbit storage field '%s' is no longer supported; use a GiB-named field such as RabbitGiB.",
+            key,
+        )
+        return 0.0
     return 0.0
 
 
@@ -595,7 +598,7 @@ class SacctReader(JobTraceReader):
 
     def validate_trace(self):
         with open(self.tracefile) as infile:
-            reader = csv.reader(infile, delimiter=self.delim)
+            reader = csv.reader(infile, delimiter=self.delim, skipinitialspace=True)
             header_fields = set(next(reader))
         required_fields = list(SacctReader.required_fields_base)
         if self.require_gpus:
@@ -612,7 +615,7 @@ class SacctReader(JobTraceReader):
         with open(self.tracefile) as infile:
             lines = [line for line in infile.readlines()
                      if not line.startswith('#')]
-            reader = csv.DictReader(lines, delimiter=self.delim)
+            reader = csv.DictReader(lines, delimiter=self.delim, skipinitialspace=True)
             jobs = [job_from_slurm_row(row) for row in reader]
         return jobs
 

--- a/src/tests/test_trace_reader.py
+++ b/src/tests/test_trace_reader.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import math
+import sys
+import types
+
+if importlib.util.find_spec("tqdm") is None:
+    tqdm_stub = types.ModuleType("tqdm")
+    tqdm_stub.tqdm = lambda *args, **kwargs: None
+    sys.modules["tqdm"] = tqdm_stub
+
+from flux_fiction._core.models import SacctReader
+
+
+def test_sacct_reader_skips_spaces_after_delimiters(tmp_path):
+    trace = tmp_path / "trace.csv"
+    trace.write_text(
+        "JobID,NNodes,NCPUS,Timelimit,Submit,Elapsed,NGPUS, RabbitGiB\n"
+        "1,1,1,00:01:00,2020-01-22T08:06:46,00:01:00,0,15000\n",
+        encoding="ascii",
+    )
+
+    reader = SacctReader(str(trace), require_gpus=True)
+    reader.validate_trace()
+    jobs = reader.read_trace()
+
+    assert len(jobs) == 1
+    assert math.isclose(
+        jobs[0].rabbit_storage_gib,
+        15000.0,
+    )
+
+
+def test_sacct_reader_rejects_legacy_gb_rabbit_field(tmp_path, caplog):
+    trace = tmp_path / "trace.csv"
+    trace.write_text(
+        "JobID,NNodes,NCPUS,Timelimit,Submit,Elapsed,NGPUS,RabbitGB\n"
+        "1,1,1,00:01:00,2020-01-22T08:06:46,00:01:00,0,15000\n",
+        encoding="ascii",
+    )
+
+    reader = SacctReader(str(trace), require_gpus=True)
+    reader.validate_trace()
+    with caplog.at_level(logging.WARNING):
+        jobs = reader.read_trace()
+
+    assert len(jobs) == 1
+    assert jobs[0].rabbit_storage_gib == 0.0
+    assert "no longer supported" in caplog.text
+    assert "RabbitGiB" in caplog.text
+
+
+def test_sacct_reader_rejects_gb_unit_in_gib_field(tmp_path, caplog):
+    trace = tmp_path / "trace.csv"
+    trace.write_text(
+        "JobID,NNodes,NCPUS,Timelimit,Submit,Elapsed,NGPUS,RabbitGiB\n"
+        "1,1,1,00:01:00,2020-01-22T08:06:46,00:01:00,0,15000GB\n",
+        encoding="ascii",
+    )
+
+    reader = SacctReader(str(trace), require_gpus=True)
+    reader.validate_trace()
+    with caplog.at_level(logging.WARNING):
+        jobs = reader.read_trace()
+
+    assert len(jobs) == 1
+    assert jobs[0].rabbit_storage_gib == 0.0
+    assert "must be expressed in GiB" in caplog.text


### PR DESCRIPTION
There was an undocumented, unlogged conversion from GB to GiB in the csv reader that caused the value of SSD in our final jobspec to be different than expected. This is now explicitly GiB.

Also fixed an issue where the reader would silently fail if there was a space in the header of the csv file.

Fixed #36 
Fixed #38 