### PR TITLE
Enabled feasibility checking and frobnicator plugin support by expanding the available flux config overrides and added support for manual jobspec overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/*.csv
 src/*.json
 /experiment_data/
 /test/
+/docs

--- a/src/flux_fiction/_adapters/flux/adapter.py
+++ b/src/flux_fiction/_adapters/flux/adapter.py
@@ -13,6 +13,35 @@ from . import watchers
 
 logger = logging.getLogger(__name__)
 
+
+def _coerce_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("1", "true", "yes", "ok"):
+            return True
+        if lowered in ("0", "false", "no"):
+            return False
+    return None
+
+
+def _infer_satisfiable(response, default=None):
+    if isinstance(response, dict):
+        for key in ("satisfiable", "feasible"):
+            if key in response:
+                value = _coerce_bool(response[key])
+                if value is not None:
+                    return value
+        if "errnum" in response:
+            try:
+                return int(response["errnum"]) == 0
+            except Exception:
+                pass
+    return default
+
 class FluxAdapter:
     def __init__(self) -> None:
         self._handle: flux.Flux | None = None
@@ -215,7 +244,7 @@ class FluxAdapter:
                     {"jobspec": jobspec_obj},
                 ).get()
                 return {
-                    "satisfiable": True,
+                    "satisfiable": _infer_satisfiable(response, default=True),
                     "method": method,
                     "response": _make_serializable(response),
                 }
@@ -232,7 +261,7 @@ class FluxAdapter:
                 },
             ).get()
             return {
-                "satisfiable": True,
+                "satisfiable": _infer_satisfiable(response, default=True),
                 "method": "sched-fluxion-resource.match",
                 "response": _make_serializable(response),
                 "attempts": attempts,

--- a/src/flux_fiction/_adapters/flux/modules.py
+++ b/src/flux_fiction/_adapters/flux/modules.py
@@ -1,4 +1,4 @@
-import logging 
+import logging
 logger = logging.getLogger(__name__)
 
 def get_loaded_modules(flux_handle):
@@ -135,31 +135,53 @@ def _load_config_object(config_source):
     )
 
 
-def _extract_qmanager_only_config(config_obj):
+def _extract_runtime_config(config_obj):
     """
-    Return a config object containing only the sched-fluxion-qmanager table.
+    Return the full config object that should be reloaded into Flux.
 
-    This avoids pushing any [resource] config that might interfere with
-    resource module args like noverify / monitor-force-up.
+    Flux Fiction may still inject ingest validator defaults, but all caller-
+    supplied config tables should be preserved when reloading modules.
     """
-    cfg = {}
-    qmgr = config_obj.get("sched-fluxion-qmanager")
-    if isinstance(qmgr, dict):
-        cfg["sched-fluxion-qmanager"] = copy.deepcopy(qmgr)
+    return copy.deepcopy(config_obj) if config_obj else {}
+
+
+def _with_default_ingest_validator_plugins(config_obj):
+    cfg = copy.deepcopy(config_obj) if config_obj else {}
+    ingest = cfg.setdefault("ingest", {})
+    validator = ingest.setdefault("validator", {})
+
+    plugins = validator.get("plugins")
+    if isinstance(plugins, list):
+        merged = ["feasibility", "jobspec"]
+        for plugin in plugins:
+            if isinstance(plugin, str) and plugin not in merged:
+                merged.append(plugin)
+        validator["plugins"] = merged
+    else:
+        validator["plugins"] = ["feasibility", "jobspec"]
+
     return cfg
+
+
+def _reload_job_ingest_config(flux_handle, config_payload, job_ingest_loaded):
+    if not job_ingest_loaded:
+        logger.debug("job-ingest not loaded; skipping explicit config reload")
+        return
+
+    flux_handle.rpc("job-ingest.config-reload", payload=config_payload).get()
 
 
 def reload_modules(flux_handle, config_source=None):
     """
     Reload resource + scheduler modules in the order:
 
-      Sched Unload -> Res Unload -> config.load(qmanager only)
+      Sched Unload -> Res Unload -> config.load(updated Flux config)
       -> Res Load(with raw args) -> Sched Load
 
     config_source may be:
       - dict from `flux config get`
       - path to a JSON file containing that object
-      - None (skip config.load entirely)
+      - None (load a minimal config enabling ingest feasibility validation)
     """
     sched_module = "sched-simple"
     sched_simple_path = None
@@ -167,6 +189,7 @@ def reload_modules(flux_handle, config_source=None):
     fluxion_qmanager_path = None
     fluxion_resource_path = None
     feasibility_module_path = None
+    job_ingest_loaded = False
 
     # config_source = "/home/j/Desktop/flux/sc25_poster/flux-fiction/experiment_data/ff_traces/experiment_scheduler_easy_resdepth32_20260330_165549/flux_config.json"
 
@@ -184,6 +207,8 @@ def reload_modules(flux_handle, config_source=None):
             fluxion_qmanager_path = module["path"]
         elif "sched-fluxion-resource" in name:
             fluxion_resource_path = module["path"]
+        elif name == "job-ingest":
+            job_ingest_loaded = True
         elif name == "resource" or "resource" in name:
             resource_module_path = module["path"]
         elif "feasibility" in name:
@@ -226,27 +251,20 @@ def reload_modules(flux_handle, config_source=None):
         logger.error("Error removing modules: %s", e)
         raise
 
-    # 2. Load ONLY qmanager config, if provided
-    if config_source is not None:
-        try:
-            qmgr_cfg = _load_config_object(config_source)
-            # qmgr_cfg = _extract_qmanager_only_config(full_cfg)
-
-            if qmgr_cfg:
-                logger.debug(
-                    "Loading qmanager-only config via config.load:\n%s",
-                    json.dumps(qmgr_cfg, indent=2, sort_keys=True),
-                )
-                flux_handle.rpc("config.load", payload=qmgr_cfg).get()
-            else:
-                logger.warning(
-                    "No sched-fluxion-qmanager table found in config source; "
-                    "skipping config.load"
-                )
-
-        except Exception as e:
-            logger.error("Error loading qmanager-only config: %s", e)
-            raise
+    # 2. Reload the caller-supplied Flux config while keeping ingest
+    # feasibility validation enabled after the module restart.
+    try:
+        config_payload = _with_default_ingest_validator_plugins(
+            _extract_runtime_config(_load_config_object(config_source))
+        )
+        logger.debug(
+            "Loading Flux config via config.load:\n%s",
+            json.dumps(config_payload, indent=2, sort_keys=True),
+        )
+        flux_handle.rpc("config.load", payload=config_payload).get()
+    except Exception as e:
+        logger.error("Error loading Flux config: %s", e)
+        raise
 
     # 3. Reload resource + scheduler
     try: 
@@ -261,6 +279,8 @@ def reload_modules(flux_handle, config_source=None):
 
         flux_handle.rpc("module.load", payload={"path": fluxion_qmanager_path,
                                                 "args": []}).get()
+
+        _reload_job_ingest_config(flux_handle, config_payload, job_ingest_loaded)
 
         start_all_queues(flux_handle)
 

--- a/src/flux_fiction/_core/engine.py
+++ b/src/flux_fiction/_core/engine.py
@@ -64,6 +64,10 @@ def run(config: object, adapter: Adapter) -> EngineResult:
     #TODO understand how jobspec_shape is generated
     jobspec_shape = resource_desc.get("jobspec_shape", {})
     rabbit_storage = resource_desc.get("rabbit_storage", {})
+    raw_jobspec_override = None
+    if getattr(config, "raw_jobspec_file", None):
+        with open(config.raw_jobspec_file, "r", encoding="utf-8") as f:
+            raw_jobspec_override = json.load(f)
     node_exclusive_accounting = bool(
         config.exclusive
         or output_vis.match_policy_is_node_exclusive(config.config_json)
@@ -116,14 +120,17 @@ def run(config: object, adapter: Adapter) -> EngineResult:
         job.trace_index = idx  
  
     for job in jobs:
-        job.set_jobspec_shape(jobspec_shape)
-        job.set_rabbit_storage_shape(
-            rabbit_storage,
-            emit_dw=config.rabbit_storage_emit_dw,
-            name=config.rabbit_storage_name,
-        )
-        if config.exclusive:
-            job.set_exclusive(resource_cores_per_node, resource_gpus_per_node)
+        if raw_jobspec_override is not None:
+            job.set_jobspec_override(raw_jobspec_override)
+        else:
+            job.set_jobspec_shape(jobspec_shape)
+            job.set_rabbit_storage_shape(
+                rabbit_storage,
+                emit_dw=config.rabbit_storage_emit_dw,
+                name=config.rabbit_storage_name,
+            )
+            if config.exclusive:
+                job.set_exclusive(resource_cores_per_node, resource_gpus_per_node)
     for job in jobs:
         job.insert_apriori_events(simulation)
     pbar = tqdm(total=len(jobs), desc="Jobs completed", unit="job", leave=True)

--- a/src/flux_fiction/_core/models.py
+++ b/src/flux_fiction/_core/models.py
@@ -108,6 +108,7 @@ class Job(object):
         self.rabbit_storage_request_count = 0
         self.rabbit_storage_emit_dw = False
         self.rabbit_storage_name = "rabbit"
+        self.raw_jobspec_override = None
 
         self.gap = float(gap or 0.0)
         self.end_latency = float(end_latency or 0.0)
@@ -257,6 +258,11 @@ class Job(object):
         self.cores_per_node = int(cores_per_node)
         self.gpus_per_node = int(gpus_per_node or 0)
         self._jobspec = None
+
+
+    def set_jobspec_override(self, jobspec_obj):
+        self.raw_jobspec_override = dict(jobspec_obj) if jobspec_obj is not None else None
+        self._jobspec = self.raw_jobspec_override
 
 
     def submit(self, adapter: Adapter):

--- a/src/flux_fiction/api/config.py
+++ b/src/flux_fiction/api/config.py
@@ -23,6 +23,7 @@ _PATH_FIELDS = {
     "job_traces": False,
     "config_file": False,
     "config_json": False,
+    "raw_jobspec_file": False,
     "resource_file": False,
     "resource_R": False,
     "output_dir": True,
@@ -128,6 +129,7 @@ class ExperimentConfig:
     job_traces: Optional[str] = None
     config_file: Optional[str] = None
     config_json: Optional[str] = None
+    raw_jobspec_file: Optional[str] = None
 
     resource_file: Optional[str] = None
     resource_R: Optional[str] = None
@@ -175,6 +177,7 @@ class ExperimentConfigModel(BaseModel):
     job_traces: Optional[str] = None
     config_file: Optional[str] = None
     config_json: Optional[str] = None
+    raw_jobspec_file: Optional[str] = None
 
     resource_file: Optional[str] = None
     resource_R: Optional[str] = None

--- a/src/flux_fiction/cli/run_ff.py
+++ b/src/flux_fiction/cli/run_ff.py
@@ -353,6 +353,9 @@ def build_inner_script(ff_root: Path, generated_config: Path, stampfile: str | N
     emergency_alloc_txt = output_dir / "emergency_allocations.txt"
     emergency_jobspecs = output_dir / "emergency_jobspecs.txt"
     emergency_flux_config = output_dir / "emergency_flux_config.json"
+    sample_jobs_path = output_dir / "sample_jobs.json"
+    sample_jobid_path = output_dir / "sample_jobid.txt"
+    sample_jobspec_path = output_dir / "sample_jobspec.json"
     args = [
         "flux-fiction",
         "--config_file",
@@ -521,6 +524,51 @@ done_path.write_text("ok\\n")
         done_path=str(emergency_done),
     )
 
+    python_capture_sample_jobspec = """
+import json
+import subprocess
+from pathlib import Path
+
+jobs_path = Path({jobs_path!r})
+jobid_path = Path({jobid_path!r})
+jobspec_path = Path({jobspec_path!r})
+
+jobs_proc = subprocess.run(
+    ["flux", "jobs", "-a", "--json"],
+    capture_output=True,
+    text=True,
+)
+if jobs_proc.returncode != 0:
+    raise SystemExit(jobs_proc.stderr or "flux jobs --json failed")
+
+jobs_path.write_text(jobs_proc.stdout, encoding="utf-8")
+payload = json.loads(jobs_proc.stdout)
+jobs = payload.get("jobs", [])
+if not jobs:
+    raise SystemExit("No jobs found in flux jobs --json output")
+
+job = jobs[0]
+jobid = str(job.get("jobid") or job.get("id") or "")
+if not jobid:
+    raise SystemExit("Could not determine jobid from flux jobs --json output")
+
+jobid_path.write_text(jobid + "\\n", encoding="utf-8")
+jobspec_proc = subprocess.run(
+    ["flux", "job", "info", jobid, "jobspec"],
+    capture_output=True,
+    text=True,
+)
+if jobspec_proc.returncode != 0:
+    raise SystemExit(jobspec_proc.stderr or f"flux job info {{jobid}} jobspec failed")
+
+jobspec_path.write_text(jobspec_proc.stdout, encoding="utf-8")
+print(jobid)
+""".format(
+        jobs_path=str(sample_jobs_path),
+        jobid_path=str(sample_jobid_path),
+        jobspec_path=str(sample_jobspec_path),
+    )
+
     return "\n".join([
         "set -euo pipefail",
         f"cd {shell_quote(ff_root)}",
@@ -557,6 +605,11 @@ done_path.write_text("ok\\n")
         "wait \"${fatal_watch_pid}\" 2>/dev/null || true",
         "if [[ -f \"${fatal_sentinel}\" ]]; then",
         "  emergency_dump || true",
+        "fi",
+        "if [[ \"${ff_rc}\" -eq 0 ]]; then",
+        "  python3 - <<'PY'",
+        python_capture_sample_jobspec.strip(),
+        "PY",
         "fi",
         "exit \"${ff_rc}\"",
     ])

--- a/src/flux_fiction/cli/run_ff_parallel.py
+++ b/src/flux_fiction/cli/run_ff_parallel.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+import run_ff

--- a/src/tests/test_feasibility_check.py
+++ b/src/tests/test_feasibility_check.py
@@ -1,0 +1,144 @@
+import json
+import importlib.util
+import sys
+import types
+
+try:
+    _flux_missing = importlib.util.find_spec("flux") is None
+except ValueError:
+    _flux_missing = "flux" not in sys.modules
+
+if _flux_missing:
+    flux_stub = types.ModuleType("flux")
+    flux_stub.Flux = type("Flux", (), {})
+    flux_stub.constants = types.SimpleNamespace(FLUX_MSGTYPE_REQUEST=0)
+
+    job_stub = types.ModuleType("flux.job")
+
+    class _DummyJournalConsumer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_callback(self, cb):
+            self._callback = cb
+
+        def start(self):
+            return None
+
+    class _DummyJobID(int):
+        @property
+        def f58(self):
+            return str(int(self))
+
+    job_stub.submit = lambda *args, **kwargs: None
+    job_stub.job_kvs_lookup = lambda *args, **kwargs: {}
+    job_stub.JobID = _DummyJobID
+    job_stub.JournalConsumer = _DummyJournalConsumer
+    job_stub.RAW = types.SimpleNamespace(cancel=lambda *args, **kwargs: None)
+
+    job_list_stub = types.ModuleType("flux.job.list")
+    job_list_stub.get_job = lambda *args, **kwargs: {}
+    job_list_stub.job_list_id = lambda *args, **kwargs: types.SimpleNamespace(
+        get_jobinfo=lambda: types.SimpleNamespace(nodelist="")
+    )
+
+    resource_stub = types.ModuleType("flux.resource")
+    resource_stub.ResourceSet = type("ResourceSet", (), {})
+
+    flux_stub.job = job_stub
+    flux_stub.resource = resource_stub
+
+    sys.modules["flux"] = flux_stub
+    sys.modules["flux.job"] = job_stub
+    sys.modules["flux.job.list"] = job_list_stub
+    sys.modules["flux.resource"] = resource_stub
+
+from flux_fiction._adapters.flux import adapter as flux_adapter_module
+from flux_fiction._adapters.flux.adapter import FluxAdapter
+
+
+class _DummyRPC:
+    def __init__(self, result=None, error=None):
+        self._result = result
+        self._error = error
+
+    def get(self):
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class _DummyHandle:
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    def rpc(self, method, payload=None):
+        self.calls.append((method, payload))
+        response = self._responses[method]
+        if isinstance(response, Exception):
+            return _DummyRPC(error=response)
+        return _DummyRPC(result=response)
+
+
+def test_check_jobspec_satisfiability_respects_scheduler_response():
+    handle = _DummyHandle({
+        "sched-fluxion-resource.satisfiability": {
+            "satisfiable": False,
+            "errnum": 19,
+            "errstr": "Unsatisfiable request",
+        },
+    })
+    adapter = FluxAdapter()
+    adapter._handle = handle
+
+    result = adapter.check_jobspec_satisfiability(json.dumps({"resources": []}))
+
+    assert result["satisfiable"] is False
+    assert result["method"] == "sched-fluxion-resource.satisfiability"
+    assert handle.calls == [
+        (
+            "sched-fluxion-resource.satisfiability",
+            {"jobspec": {"resources": []}},
+        )
+    ]
+
+
+def test_check_jobspec_satisfiability_falls_back_to_match_rpc():
+    handle = _DummyHandle({
+        "sched-fluxion-resource.satisfiability": RuntimeError("no service"),
+        "feasibility.check": RuntimeError("no service"),
+        "sched-fluxion-resource.match": {"R": "match"},
+    })
+    adapter = FluxAdapter()
+    adapter._handle = handle
+
+    jobspec = {"resources": [{"type": "node", "count": 2}]}
+    result = adapter.check_jobspec_satisfiability(json.dumps(jobspec))
+
+    assert result["satisfiable"] is True
+    assert result["method"] == "sched-fluxion-resource.match"
+    assert [call[0] for call in handle.calls] == [
+        "sched-fluxion-resource.satisfiability",
+        "feasibility.check",
+        "sched-fluxion-resource.match",
+    ]
+
+
+def test_submit_job_does_not_call_feasibility_rpc(monkeypatch):
+    submitted = []
+
+    def fake_submit(handle, jobspec_json):
+        submitted.append((handle, jobspec_json))
+        return 1234
+
+    monkeypatch.setattr(flux_adapter_module.flux.job, "submit", fake_submit)
+
+    adapter = FluxAdapter()
+    adapter._handle = object()
+    jobspec_json = json.dumps({"resources": [{"type": "slot", "count": 1}]})
+
+    jobid = adapter.submit_job(jobspec_json)
+
+    assert jobid == 1234
+    assert submitted == [(adapter._handle, jobspec_json)]

--- a/src/tests/test_flux_module_config.py
+++ b/src/tests/test_flux_module_config.py
@@ -1,0 +1,129 @@
+from flux_fiction._adapters.flux import modules
+
+
+class _DummyRPC:
+    def __init__(self, result=None):
+        self._result = result if result is not None else {}
+
+    def get(self):
+        return self._result
+
+
+class _DummyHandle:
+    def __init__(self, mods):
+        self._mods = mods
+        self.calls = []
+
+    def rpc(self, method, payload=None, nodeid=None):
+        self.calls.append((method, payload, nodeid))
+        if method == "module.list":
+            return _DummyRPC({"mods": self._mods})
+        return _DummyRPC({})
+
+
+def _loaded_fluxion_modules():
+    return [
+        {
+            "name": "job-ingest",
+            "path": "/tmp/job-ingest.so",
+            "services": [],
+        },
+        {
+            "name": "sched-fluxion-qmanager",
+            "path": "/tmp/sched-fluxion-qmanager.so",
+            "services": [],
+        },
+        {
+            "name": "sched-fluxion-resource",
+            "path": "/tmp/sched-fluxion-resource.so",
+            "services": [],
+        },
+        {
+            "name": "sched-fluxion-feasibility",
+            "path": "/tmp/sched-fluxion-feasibility.so",
+            "services": [],
+        },
+        {
+            "name": "resource",
+            "path": "/tmp/resource.so",
+            "services": [],
+        },
+    ]
+
+
+def _config_load_payload(handle):
+    for method, payload, _nodeid in handle.calls:
+        if method == "config.load":
+            return payload
+    raise AssertionError("config.load was not called")
+
+
+def _job_ingest_reload_payload(handle):
+    for method, payload, _nodeid in handle.calls:
+        if method == "job-ingest.config-reload":
+            return payload
+    raise AssertionError("job-ingest.config-reload was not called")
+
+
+def test_reload_modules_injects_feasibility_validator_without_config_source():
+    handle = _DummyHandle(_loaded_fluxion_modules())
+
+    modules.reload_modules(handle, None)
+
+    assert _config_load_payload(handle) == {
+        "ingest": {
+            "validator": {
+                "plugins": ["feasibility", "jobspec"],
+            }
+        }
+    }
+    assert _job_ingest_reload_payload(handle) == {
+        "ingest": {
+            "validator": {
+                "plugins": ["feasibility", "jobspec"],
+            }
+        }
+    }
+
+
+def test_reload_modules_preserves_existing_validator_plugins():
+    handle = _DummyHandle(_loaded_fluxion_modules())
+    config = {
+        "sched-fluxion-qmanager": {"queue-policy": "easy"},
+        "sched-fluxion-resource": {
+            "match-policy": "firstnodex",
+            "match-format": "rv1_noexec",
+        },
+        "ingest": {
+            "validator": {
+                "plugins": ["require-instance", "jobspec"],
+            }
+        },
+    }
+
+    modules.reload_modules(handle, config)
+
+    assert _config_load_payload(handle) == {
+        "sched-fluxion-qmanager": {"queue-policy": "easy"},
+        "sched-fluxion-resource": {
+            "match-policy": "firstnodex",
+            "match-format": "rv1_noexec",
+        },
+        "ingest": {
+            "validator": {
+                "plugins": ["feasibility", "jobspec", "require-instance"],
+            }
+        },
+    }
+    assert _job_ingest_reload_payload(handle) == {
+        "sched-fluxion-qmanager": {"queue-policy": "easy"},
+        "sched-fluxion-resource": {
+            "match-policy": "firstnodex",
+            "match-format": "rv1_noexec",
+        },
+        "ingest": {
+            "validator": {
+                "plugins": ["feasibility", "jobspec", "require-instance"],
+            }
+        },
+    }

--- a/src/tests/test_rabbit_storage_jobspec.py
+++ b/src/tests/test_rabbit_storage_jobspec.py
@@ -82,3 +82,44 @@ def test_rabbit_storage_capacity_prefers_storage_size_over_share_count():
     })
 
     assert capacities["ssd"] == 1153692.0
+
+
+def test_jobspec_override_bypasses_generated_shape():
+    job = Job(
+        nnodes=4,
+        ncpus=160,
+        submit_time=0,
+        elapsed_time=10,
+        timelimit=20,
+        rabbit_storage_gib=8154.0,
+    )
+    override = {
+        "version": 1,
+        "resources": [
+            {
+                "type": "slot",
+                "count": 1,
+                "label": "rabbit",
+                "with": [
+                    {
+                        "type": "node",
+                        "count": 1,
+                        "with": [
+                            {
+                                "type": "slot",
+                                "count": 1,
+                                "label": "task",
+                                "with": [{"type": "core", "count": 1}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "tasks": [{"command": ["hostname"], "slot": "task", "count": {"per_slot": 1}}],
+        "attributes": {"system": {"duration": 0}},
+    }
+
+    job.set_jobspec_override(override)
+
+    assert job.jobspec == override


### PR DESCRIPTION
While debugging some issues in flux-sched, I found that we were omitting several key configuration options in our config loader whenever we setup Flux. The two important ones here were the feasibility checking from the `job-ingest` module and the `defaults` and `constraints` frobnicator plugins in `flux-core`. To be able to test these changes, I needed a more flexible way of defining input jobspecs, so I added the ability to inject custom jobspecs as an override to the default jobspec generator. 